### PR TITLE
Correct curly quotes and missing quote in deepsort_params in Config.toml

### DIFF
--- a/Sports2D/Demo/Config_demo.toml
+++ b/Sports2D/Demo/Config_demo.toml
@@ -89,7 +89,7 @@ det_frequency = 4       # Run person detection only every N frames, and inbetwee
 device = 'auto' # 'auto', 'CPU', 'CUDA', 'MPS', 'ROCM'
 backend = 'auto' # 'auto', 'openvino', 'onnxruntime', 'opencv'
 tracking_mode = 'sports2d' # 'sports2d' or 'deepsort'. 'deepsort' is slower, harder to parametrize but can be more robust if correctly tuned
-# deepsort_params = """{'max_age':30, 'n_init':3, 'max_cosine_distance':0.3, 'max_iou_distance':0.8, 'embedder_gpu': True, embedder':'torchreid'}""" # """{dictionary between 3 double quotes}"""
+# deepsort_params = """{'max_age':30, 'n_init':3, 'max_cosine_distance':0.3, 'max_iou_distance':0.8, 'embedder_gpu': True, 'embedder':'torchreid'}""" # """{dictionary between 3 double quotes}"""
                   # More robust in crowded scenes but tricky to parametrize. More information there: https://github.com/levan92/deep_sort_realtime/blob/master/deep_sort_realtime/deepsort_tracker.py#L51
                   # Requires `pip install torch torchvision torchreid gdown tensorboard`
 


### PR DESCRIPTION
Hello Dr. David,

Happy New Year! I hope 2026 is filled with health, happiness, and all the best for you.
 
I came across some typos when I tried to run sports2d with deepsort.

When running sports2d --config Config.toml with tracking_mode = 'deepsort', the following error occurs:
`TypeError: DeepSort.__init__() got an unexpected keyword argument ''max_age''`

The deepsort_params value in Config.toml contains two issues:

- Curly quotes instead of straight quotes: The dictionary keys use curly quotes ('max_age') instead of standard straight quotes ('max_age'), causing the parameter name to be parsed as 'max_age' (with embedded curly quotes).
- Missing opening quote for embedder key: The embedder key was written as embedder':'torchreid' instead of 'embedder':'torchreid'.

After fixing it, it works well! 

Thank you for your consideration.

Sincerely,
HunMin Kim